### PR TITLE
Raw to digi updates

### DIFF
--- a/DQM/CTPPS/test/diamond_dqm_test_xml_cfg.py
+++ b/DQM/CTPPS/test/diamond_dqm_test_xml_cfg.py
@@ -1,0 +1,103 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_cff import Run3
+
+process = cms.Process('RECODQM', Run3)
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10000) )
+process.verbosity = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+# minimum of logs
+process.MessageLogger = cms.Service("MessageLogger",
+    cerr = cms.untracked.PSet(
+        threshold = cms.untracked.string('WARNING')
+    )
+)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+# load DQM framework
+process.load("DQM.Integration.config.environment_cfi")
+process.dqmEnv.subSystemFolder = "CTPPS"
+process.dqmEnv.eventInfoFolder = "EventInfo"
+process.dqmSaver.path = ""
+process.dqmSaver.tag = "CTPPS"
+
+# raw data source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+    # '/store/data/Run2018D/ZeroBias/AOD/12Nov2019_UL2018_rsb-v1/280000/FE61A0D8-CEDC-2142-81AA-06301F452792.root',
+    '/store/data/Run2023D/ZeroBias/RAW/v1/000/370/749/00000/00e73a77-d415-499d-991e-6efd707f12e6.root'
+    ),
+)
+
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+from Configuration.AlCa.autoCond import autoCond
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_hlt_relval', '')
+# process.GlobalTag = GlobalTag(process.GlobalTag, '120X_dataRun2_v2', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, autoCond['run3_data_prompt'], '')
+
+process.GlobalTag.toGet = cms.VPSet(
+        cms.PSet(record = cms.string("TotemReadoutRcd"),
+                 tag = cms.string("PPSDAQMapping_TrackingStrip_test_v1"),
+                 connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"),
+                 label = cms.untracked.string("TrackingStrip")
+                 ),
+        cms.PSet(record = cms.string("TotemReadoutRcd"),
+                 tag = cms.string("PPSDAQMapping_TimingDiamond_test_v1"),
+                 connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"),
+                 label = cms.untracked.string("TimingDiamond")
+                 ),
+        cms.PSet(record = cms.string("TotemReadoutRcd"),
+                 tag = cms.string("PPSDAQMapping_TotemTiming_test_v1"),
+                 connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"),
+                 label = cms.untracked.string("TotemTiming")
+                 ),
+        cms.PSet(record = cms.string("TotemReadoutRcd"),
+                 tag = cms.string("PPSDAQMapping_TotemT2_test_v1"),
+                 connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"),
+                 label = cms.untracked.string("TotemT2")
+                 ),
+        cms.PSet(record = cms.string("TotemAnalysisMaskRcd"),
+                 tag = cms.string("PPSAnalysisMask_test_v1"),
+                 connect = cms.string("frontier://FrontierPrep/CMS_CONDITIONS"),
+                 )
+        )
+
+# raw-to-digi conversion
+process.load("EventFilter.CTPPSRawToDigi.ctppsRawToDigi_xml_cff")
+
+# prefer mappings from XML files
+process.es_prefer_totemTimingMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TotemTiming", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TotemTiming"))
+process.es_prefer_totemDiamondMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TimingDiamond", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TimingDiamond"))
+process.es_prefer_totemT2Mapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TotemT2", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TotemT2"))
+process.es_prefer_TrackingStripMapping = cms.ESPrefer("TotemDAQMappingESSourceXML", "totemDAQMappingESSourceXML_TrackingStrip", TotemReadoutRcd=cms.vstring("TotemDAQMapping/TrackingStrip"))
+
+# local RP reconstruction chain with standard settings
+process.load("RecoPPS.Configuration.recoCTPPS_cff")
+process.load('Geometry.VeryForwardGeometry.geometryRPFromDD_2021_cfi')
+# CTPPS DQM modules
+process.load("DQM.CTPPS.ctppsDQM_cff")
+process.ctppsDiamondDQMSource.excludeMultipleHits = cms.bool(True)
+process.ctppsDiamondDQMSource.plotOnline = cms.untracked.bool(True)
+process.ctppsDiamondDQMSource.plotOffline = cms.untracked.bool(False)
+process.path = cms.Path(
+    process.ctppsRawToDigi*
+    process.recoCTPPS*
+    process.ctppsDQMOnlineSource*
+    process.ctppsDQMOnlineHarvest
+)
+
+process.end_path = cms.EndPath(
+    process.dqmEnv +
+    process.dqmSaver
+)
+
+process.schedule = cms.Schedule(
+    process.path,
+    process.end_path
+)

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -25,6 +25,7 @@
 #include "DataFormats/CTPPSDigi/interface/TotemFEDInfo.h"
 
 #include "CondFormats/DataRecord/interface/TotemReadoutRcd.h"
+#include "CondFormats/DataRecord/interface/TotemAnalysisMaskRcd.h"
 #include "CondFormats/PPSObjects/interface/TotemDAQMapping.h"
 #include "CondFormats/PPSObjects/interface/TotemAnalysisMask.h"
 
@@ -58,7 +59,7 @@ private:
 
   edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
   edm::ESGetToken<TotemDAQMapping, TotemReadoutRcd> totemMappingToken;
-  edm::ESGetToken<TotemAnalysisMask, TotemReadoutRcd> analysisMaskToken;
+  edm::ESGetToken<TotemAnalysisMask, TotemAnalysisMaskRcd> analysisMaskToken;
 
   pps::RawDataUnpacker rawDataUnpacker;
   RawToDigiConverter rawToDigiConverter;
@@ -145,7 +146,7 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
   produces<DetSetVector<TotemVFATStatus>>(subSystemName);
 
   totemMappingToken = esConsumes<TotemDAQMapping, TotemReadoutRcd>(ESInputTag("", subSystemName));
-  analysisMaskToken = esConsumes<TotemAnalysisMask, TotemReadoutRcd>(ESInputTag("", subSystemName));
+  analysisMaskToken = esConsumes<TotemAnalysisMask, TotemAnalysisMaskRcd>(ESInputTag("", subSystemName));
 }
 
 TotemVFATRawToDigi::~TotemVFATRawToDigi() {}
@@ -168,9 +169,19 @@ template <typename DigiType>
 void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
   // get DAQ mapping
   ESHandle<TotemDAQMapping> mapping = es.getHandle(totemMappingToken);
+  if (!mapping) {
+    LogError("TotemVFATRawToDigi") << "TotemVFATRawToDigi: no mapping found for " << subSystemName;
+  }
 
   // get analysis mask to mask channels
-  ESHandle<TotemAnalysisMask> analysisMask = es.getHandle(analysisMaskToken);
+  TotemAnalysisMask analysisMask;
+  ESHandle<TotemAnalysisMask> analysisMaskHandle = es.getHandle(analysisMaskToken);
+  if (analysisMaskHandle) {
+    analysisMask = *analysisMaskHandle;
+  } else {
+    LogWarning("TotemVFATRawToDigi") << "TotemVFATRawToDigi: no mask found for " << subSystemName;
+    analysisMask = *(std::make_unique<TotemAnalysisMask>());
+  }
 
   // raw data handle
   edm::Handle<FEDRawDataCollection> rawData;
@@ -190,7 +201,7 @@ void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
   }
 
   // raw-to-digi conversion
-  rawToDigiConverter.run(vfatCollection, *mapping, *analysisMask, digi, conversionStatus);
+  rawToDigiConverter.run(vfatCollection, *mapping, analysisMask, digi, conversionStatus);
 
   // commit products to event
   event.put(make_unique<vector<TotemFEDInfo>>(fedInfo), subSystemName);

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_cff.py
@@ -1,51 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 # ---------- Si strips ----------
-totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(0),
-  subSystem = cms.untracked.string("TrackingStrip"),
-  sampicSubDetId = cms.uint32(6),
-  configuration = cms.VPSet(
-    # 2016, before TS2
-    cms.PSet(
-      validityRange = cms.EventRange("1:min - 280385:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_to_fill_5288.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2016, during TS2
-    cms.PSet(
-      validityRange = cms.EventRange("280386:min - 281600:max"),
-      mappingFileNames = cms.vstring(),
-      maskFileNames = cms.vstring()
-    ),
-    # 2016, after TS2
-    cms.PSet(
-      validityRange = cms.EventRange("281601:min - 290872:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_from_fill_5330.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2017
-    cms.PSet(
-      validityRange = cms.EventRange("290873:min - 311625:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2017.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2018
-    cms.PSet(
-      validityRange = cms.EventRange("311626:min - 339999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2018.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2022
-    cms.PSet(
-      validityRange = cms.EventRange("340000:min - 999999999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml"),
-      maskFileNames = cms.vstring()
-    )
-
-  )
-)
-
 from EventFilter.CTPPSRawToDigi.totemRPRawToDigi_cfi import totemRPRawToDigi
 totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 
@@ -56,86 +11,14 @@ totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
 #  totemRPRawToDigi.RawToDigi.printUnknownFrameSummary = True
 
 # ---------- diamonds ----------
-totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(0),
-  subSystem = cms.untracked.string("TimingDiamond"),
-  sampicSubDetId = cms.uint32(6),
-  configuration = cms.VPSet(
-    # 2016, before diamonds inserted in DAQ
-    cms.PSet(
-      validityRange = cms.EventRange("1:min - 283819:max"),
-      mappingFileNames = cms.vstring(),
-      maskFileNames = cms.vstring()
-    ),
-    # 2016, after diamonds inserted in DAQ
-    cms.PSet(
-      validityRange = cms.EventRange("283820:min - 292520:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2017
-    cms.PSet(
-      validityRange = cms.EventRange("292521:min - 310000:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2017.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2018
-    cms.PSet(
-      validityRange = cms.EventRange("310001:min - 339999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2018.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2022
-    cms.PSet(
-      validityRange = cms.EventRange("340000:min - 362919:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2023
-    cms.PSet(
-      validityRange = cms.EventRange("362920:min - 999999999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2023.xml"),
-      maskFileNames = cms.vstring()
-    )
-
-  )
-)
-
 from EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi import ctppsDiamondRawToDigi
 ctppsDiamondRawToDigi.rawDataTag = "rawDataCollector"
 
 # ---------- Totem Timing ----------
-totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
-  verbosity = cms.untracked.uint32(0),
-  subSystem = cms.untracked.string("TotemTiming"),
-  sampicSubDetId = cms.uint32(5),
-  configuration = cms.VPSet(
-    # 2017, before detector inserted in DAQ
-    cms.PSet(
-      validityRange = cms.EventRange("1:min - 310000:max"),
-      mappingFileNames = cms.vstring(),
-      maskFileNames = cms.vstring()
-    ),
-    # 2018
-    cms.PSet(
-      validityRange = cms.EventRange("310001:min - 339999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2018.xml"),
-      maskFileNames = cms.vstring()
-    ),
-    # 2022
-    cms.PSet(
-      validityRange = cms.EventRange("340000:min - 999999999:max"),
-      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml"),
-      maskFileNames = cms.vstring()
-    )
-  )
-)
-
 from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawToDigi
 totemTimingRawToDigi.rawDataTag = "rawDataCollector"
 
 # ---------- Totem nT2 ----------
-from CalibPPS.ESProducers.totemT2DAQMapping_cff import totemDAQMappingESSourceXML as totemDAQMappingESSourceXML_TotemT2
 from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
 totemT2Digis.rawDataTag = "rawDataCollector"
 
@@ -147,7 +30,6 @@ from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
 from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
 from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
 (ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
-(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = 6)
 
 # raw-to-digi task and sequence
 ctppsRawToDigiTask = cms.Task(

--- a/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_xml_cff.py
+++ b/EventFilter/CTPPSRawToDigi/python/ctppsRawToDigi_xml_cff.py
@@ -1,0 +1,160 @@
+import FWCore.ParameterSet.Config as cms
+
+# ---------- Si strips ----------
+totemDAQMappingESSourceXML_TrackingStrip = cms.ESSource("TotemDAQMappingESSourceXML",
+  verbosity = cms.untracked.uint32(0),
+  subSystem = cms.untracked.string("TrackingStrip"),
+  sampicSubDetId = cms.uint32(6),
+  configuration = cms.VPSet(
+    # 2016, before TS2
+    cms.PSet(
+      validityRange = cms.EventRange("1:min - 280385:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_to_fill_5288.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, during TS2
+    cms.PSet(
+      validityRange = cms.EventRange("280386:min - 281600:max"),
+      mappingFileNames = cms.vstring(),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, after TS2
+    cms.PSet(
+      validityRange = cms.EventRange("281601:min - 290872:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2016_from_fill_5330.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2017
+    cms.PSet(
+      validityRange = cms.EventRange("290873:min - 311625:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2017.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("311626:min - 339999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_tracking_strip_2022.xml"),
+      maskFileNames = cms.vstring()
+    )
+
+  )
+)
+
+from EventFilter.CTPPSRawToDigi.totemRPRawToDigi_cfi import totemRPRawToDigi
+totemRPRawToDigi.rawDataTag = cms.InputTag("rawDataCollector")
+
+# various error/warning/info output may be enabled with these flags
+#  totemRPRawToDigi.RawUnpacking.verbosity = 1
+#  totemRPRawToDigi.RawToDigi.verbosity = 1 # or higher number for more output
+#  totemRPRawToDigi.RawToDigi.printErrorSummary = True
+#  totemRPRawToDigi.RawToDigi.printUnknownFrameSummary = True
+
+# ---------- diamonds ----------
+totemDAQMappingESSourceXML_TimingDiamond = cms.ESSource("TotemDAQMappingESSourceXML",
+  verbosity = cms.untracked.uint32(0),
+  subSystem = cms.untracked.string("TimingDiamond"),
+  sampicSubDetId = cms.uint32(6),
+  configuration = cms.VPSet(
+    # 2016, before diamonds inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("1:min - 283819:max"),
+      mappingFileNames = cms.vstring(),
+      maskFileNames = cms.vstring()
+    ),
+    # 2016, after diamonds inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("283820:min - 292520:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2017
+    cms.PSet(
+      validityRange = cms.EventRange("292521:min - 310000:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2017.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("310001:min - 339999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 362919:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2022.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2023
+    cms.PSet(
+      validityRange = cms.EventRange("362920:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_timing_diamond_2023.xml"),
+      maskFileNames = cms.vstring()
+    )
+
+  )
+)
+
+from EventFilter.CTPPSRawToDigi.ctppsDiamondRawToDigi_cfi import ctppsDiamondRawToDigi
+ctppsDiamondRawToDigi.rawDataTag = "rawDataCollector"
+
+# ---------- Totem Timing ----------
+totemDAQMappingESSourceXML_TotemTiming = cms.ESSource("TotemDAQMappingESSourceXML",
+  verbosity = cms.untracked.uint32(0),
+  subSystem = cms.untracked.string("TotemTiming"),
+  sampicSubDetId = cms.uint32(5),
+  configuration = cms.VPSet(
+    # 2017, before detector inserted in DAQ
+    cms.PSet(
+      validityRange = cms.EventRange("1:min - 310000:max"),
+      mappingFileNames = cms.vstring(),
+      maskFileNames = cms.vstring()
+    ),
+    # 2018
+    cms.PSet(
+      validityRange = cms.EventRange("310001:min - 339999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2018.xml"),
+      maskFileNames = cms.vstring()
+    ),
+    # 2022
+    cms.PSet(
+      validityRange = cms.EventRange("340000:min - 999999999:max"),
+      mappingFileNames = cms.vstring("CondFormats/PPSObjects/xml/mapping_totem_timing_2022.xml"),
+      maskFileNames = cms.vstring()
+    )
+  )
+)
+
+from EventFilter.CTPPSRawToDigi.totemTimingRawToDigi_cfi import totemTimingRawToDigi
+totemTimingRawToDigi.rawDataTag = "rawDataCollector"
+
+# ---------- Totem nT2 ----------
+from CalibPPS.ESProducers.totemT2DAQMapping_cff import totemDAQMappingESSourceXML as totemDAQMappingESSourceXML_TotemT2
+from EventFilter.CTPPSRawToDigi.totemT2Digis_cfi import totemT2Digis
+totemT2Digis.rawDataTag = "rawDataCollector"
+
+# ---------- pixels ----------
+from EventFilter.CTPPSRawToDigi.ctppsPixelDigis_cfi import ctppsPixelDigis
+ctppsPixelDigis.inputLabel = "rawDataCollector"
+
+from Configuration.Eras.Modifier_ctpps_2016_cff import ctpps_2016
+from Configuration.Eras.Modifier_ctpps_2017_cff import ctpps_2017
+from Configuration.Eras.Modifier_ctpps_2018_cff import ctpps_2018
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(ctppsPixelDigis, isRun3 = False )
+(ctpps_2016 | ctpps_2017 | ctpps_2018).toModify(totemDAQMappingESSourceXML_TotemTiming, sampicSubDetId = 6)
+
+# raw-to-digi task and sequence
+ctppsRawToDigiTask = cms.Task(
+  totemRPRawToDigi,
+  ctppsDiamondRawToDigi,
+  totemTimingRawToDigi,
+  totemT2Digis,
+  ctppsPixelDigis
+)
+ctppsRawToDigi = cms.Sequence(ctppsRawToDigiTask)


### PR DESCRIPTION
#### PR description:

This PR is a next step in a way to resolve an issue from - Transfer of all PPS detectors' mappings from XML to CondDB.

In this PR:

- Updates of [TotemVFATRawToDigi.cc](https://github.com/CTPPS/cmssw/blob/6105ec09f9adba0ecaa36a6ab1ac23f249a67c6f/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc)
    - add use of new TotemAnalysisMaskRcd separated from TotemReadoutRcd and introduced in
    - handle retrieving objects from records using `EventSetup::getHandle()`
    
- Changes in [ctppsRawToDigi_cff.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-1eb4c964687bc0dbea0102fa7d717cc7f42908aa1979fbc22cde1db187b8e3fa):
    - remove imports of XML files containing mappings - now mappings will be taken from a GT
- New config fragment: [ctppsRawToDigi_xml_cff.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-ca62e8d0446df10a4cd189d5eabaecbaf40ca005968588089ab54e075954ad6a) which is an old [ctppsRawToDigi_cff.py](https://github.com/cms-sw/cmssw/compare/master...CTPPS:cmssw:raw_to_digi_updates#diff-1eb4c964687bc0dbea0102fa7d717cc7f42908aa1979fbc22cde1db187b8e3fa) - it imports XML files with mappings
- New config ([diamond_dqm_test_xml_cfg.py](https://github.com/brzozia/cmssw/compare/master...brzozia:cmssw:raw_to_digi_updates?expand=1#diff-ff8a8ac4432134200935d2de6e7605082f76c71bf3d2ab70bda10bbf7d4bb828)) to read mappings from XML instead of GT (just for test and internal use)


#### PR validation:

We have created Tags containing records with mappings for each detector. Created Tags:

TAG | Record
-- | --
PPSDAQMapping_TrackingStrip_test_v1 | TotemReadoutRcd
PPSDAQMapping_TimingDiamond_test_v1 | TotemReadoutRcd
PPSDAQMapping_TotemTiming_test_v1 | TotemReadoutRcd
PPSDAQMapping_TotemT2_test_v1 | TotemReadoutRcd
PPSAnalysisMask_test_v1 | TotemAnalysisMaskRcd


To validate changes in TotemVFATRawToDigi I ran the rawToDigi and the reconstruction with the use of XML files and with the use of Tags.

Then I compared plots generated with the use of Tags with plots generated with the use of XMLs. They looked the same.

This test has been done for all detectors (TimingDiamond, TrackingStrips, TotemT2, TotemTiming).

